### PR TITLE
Handle PKGBUILD files generated by services

### DIFF
--- a/set_version
+++ b/set_version
@@ -158,7 +158,8 @@ for my $file (@files) {
 use Digest::MD5;
 
 # handle arch linux PKGBUILD files
-if ( -e "PKGBUILD" ) {
+@files = grep {$_ =~ /PKGBUILD$/} @srcfiles;
+for my $pkgbuild (@files) {
   # find md5sum of tar ball
   my $md5sum;
   my $tarfile;
@@ -184,7 +185,7 @@ if ( -e "PKGBUILD" ) {
   close(FILE);
 
   die ("Failed to calculate md5sum") unless $md5sum;
-  replace_tag("PKGBUILD", "pkgver", $version);
-  replace_tag("PKGBUILD", "pkgrel", "0");
-  replace_tag("PKGBUILD", "md5sums", "('".$md5sum."')");
+  replace_tag($pkgbuild, "pkgver", $version);
+  replace_tag($pkgbuild, "pkgrel", "0");
+  replace_tag($pkgbuild, "md5sums", "('".$md5sum."')");
 }


### PR DESCRIPTION
In contrast to dsc/spec files, set_version does not handle PKGBUILD files generated by a service (eg extract_files https://build.opensuse.org/package/show?package=grandorgue&project=home%3Ae9925248%3Agrandorgue )
