### PR TITLE
Some general fixes plus support for setting the version in debian.changelog files

### DIFF
--- a/set_version
+++ b/set_version
@@ -80,6 +80,9 @@ opendir(D, ".") || return ();
 my @srcfiles = grep {$_ ne '.' && $_ ne '..'} readdir(D);
 closedir D;
 
+# sorted local file list by modification time (newest first)
+@srcfiles = sort { -M "$a" <=> -M "$b" } (@srcfiles);
+
 # Detect version based on file names
 unless ($version) {
   my @binsufs = qw{tar tar.gz tgz tar.bz2 tbz2 tar.xz zip};


### PR DESCRIPTION
Changes the version in the debian.changelog file is necessary if this is used in combination with tar_scm's versionformat parameter.
