### PR TITLE
Fix tar file detection for PKGBUILD

### DIFF
--- a/set_version
+++ b/set_version
@@ -217,14 +217,14 @@ for my $pkgbuild (grep {$_ =~ /PKGBUILD$/} @files) {
   my $md5sum;
   my $tarfile;
   for my $file (@srcfiles) {
-    if ( $file =~ /^_service:.*[-_]$version.*/ ) {
+    if ( $file =~ /^_service:.*[-_]\Q$version\E.*/ ) {
       $tarfile = $file;
       last;
     }
   }
   unless($tarfile) {
     for my $file (@srcfiles) {
-      if ( $file =~ /.*[-_]$version.*/ ) {
+      if ( $file =~ /.*[-_]\Q$version\E.*/ ) {
         $tarfile = $file;
         last;
       }


### PR DESCRIPTION
The version string can contain regular expression special characters like '+'.
To escape the version string, use \Q and \E.