### PR TITLE
fix when switching from .dev to non-dev version

### DIFF
--- a/set_version
+++ b/set_version
@@ -318,9 +318,9 @@ if __name__ == '__main__':
     for f in filter(lambda x: x.endswith(".spec"), files):
         filename = outdir + "/" + f
         shutil.copyfile(f, filename)
+        _add_or_replace_define(filename, "version_unconverted", version)
         if version_converted and version_converted != version:
             _replace_tag(filename, 'Version', version_converted)
-            _add_or_replace_define(filename, "version_unconverted", version)
             _replace_spec_setup(filename, "version_unconverted")
         else:
             _replace_tag(filename, 'Version', version)

--- a/tests/test_rpmspec.py
+++ b/tests/test_rpmspec.py
@@ -177,6 +177,20 @@ class SetVersionSpecfile(SetVersionBaseTest):
             "test-master.tar",
             [],
             ["test-5.0.0.0b2dev188/test.egg-info/PKG-INFO"]
+        ),
+        (
+            "test.spec",
+            [
+                "Version: 5.0.0.0~b2~dev188",
+                "%define version_unconverted 5.0.0.0b2dev188",
+            ],
+            [
+                "Version: 5.1.0",
+                "%define version_unconverted 5.1.0",
+            ],
+            "test-master.tar",
+            [],
+            ["test-5.1.0/test.egg-info/PKG-INFO"]
         )
     )
     @unpack


### PR DESCRIPTION
the setup call would still reference unconverted_version  
which still had the old value