### PR TITLE
Allow version to have a 'v' prefix (fixes #30)

### DIFF
--- a/set_version
+++ b/set_version
@@ -65,8 +65,8 @@ class VersionDetector(object):
     def _get_version_via_filename(files, basename):
         """ detect version based on file names"""
         for f in files:
-            regex = r"^%s.*[-_]([\d].*)\.(?:%s)$" % (re.escape(basename),
-                                                     suffixes_re)
+            regex = r"^%s.*[-_]v?([\d].*)\.(?:%s)$" % (re.escape(basename),
+                                                       suffixes_re)
             m = re.match(regex, f)
             if m:
                 return m.group(1)
@@ -75,7 +75,7 @@ class VersionDetector(object):
 
     @staticmethod
     def __get_version(str_list, basename):
-        regex = "%s.*[-_]([\d][^\/]*).*" % basename
+        regex = "%s.*[-_]v?([\d][^\/]*).*" % basename
         for s in str_list:
             m = re.match(regex, s)
             if m:

--- a/tests/data_test_from_tarball_with_basename.json
+++ b/tests/data_test_from_tarball_with_basename.json
@@ -1,6 +1,20 @@
 [
   ["testprog-1.2.3.tar", [], "1.2.3"],
+  ["testprog-v1.2.3.tar", [], "1.2.3"],
   ["testprog-1.2.3.tar", ["xyz-4.5.6"], "1.2.3"],
+  ["testprog-v1.2.3.tar", ["xyz-4.5.6"], "1.2.3"],
+  ["testprog-1.2.3.tar", ["xyz-v4.5.6"], "1.2.3"],
+  ["testprog-v1.2.3.tar", ["xyz-v4.5.6"], "1.2.3"],
   ["helloworld-1.2.3.tar", ["testprog-4.5.6"], "4.5.6"],
-  ["helloworld-1.2.3.tar", ["testprog-4.5.6", "another-testprog-7"], "4.5.6"]
+  ["helloworld-1.2.3.tar", ["testprog-v4.5.6"], "4.5.6"],
+  ["helloworld-v1.2.3.tar", ["testprog-4.5.6"], "4.5.6"],
+  ["helloworld-v1.2.3.tar", ["testprog-v4.5.6"], "4.5.6"],
+  ["helloworld-1.2.3.tar", ["testprog-4.5.6", "another-testprog-7"], "4.5.6"],
+  ["helloworld-1.2.3.tar", ["testprog-v4.5.6", "another-testprog-7"], "4.5.6"],
+  ["helloworld-1.2.3.tar", ["testprog-4.5.6", "another-testprog-v7"], "4.5.6"],
+  ["helloworld-1.2.3.tar", ["testprog-v4.5.6", "another-testprog-v7"], "4.5.6"],
+  ["helloworld-v1.2.3.tar", ["testprog-4.5.6", "another-testprog-7"], "4.5.6"],
+  ["helloworld-v1.2.3.tar", ["testprog-v4.5.6", "another-testprog-7"], "4.5.6"],
+  ["helloworld-v1.2.3.tar", ["testprog-4.5.6", "another-testprog-v7"], "4.5.6"],
+  ["helloworld-v1.2.3.tar", ["testprog-v4.5.6", "another-testprog-v7"], "4.5.6"]
 ]


### PR DESCRIPTION
This pull request should fix issue #30 and ignore the v if v0.1 style version tagging is used as is common place on GitHub.
