### PR TITLE
Don't add unconverted_version unconditionally

### DIFF
--- a/set_version
+++ b/set_version
@@ -146,7 +146,7 @@ class PackageTypeDetector(object):
         return False
 
 
-def _add_or_replace_define(filename, def_name, def_value):
+def _replace_define(filename, def_name, def_value, add_if_missing=True):
     # first, modify a copy of filename and then move it
     with open(filename, 'r+') as f:
         contents = f.read()
@@ -157,7 +157,7 @@ def _add_or_replace_define(filename, def_name, def_value):
             r'%define {def_name}\g<1>{def_value}'.format(
                 def_name=def_name, def_value=def_value),
             contents, flags=re.MULTILINE)
-        if subs == 0:
+        if subs == 0 and add_if_missing:
             # seems there was no define. add new one before 'Name:'
             contents_new, subs = re.subn(
                 r'^(Name:.*)$',
@@ -318,8 +318,10 @@ if __name__ == '__main__':
     for f in filter(lambda x: x.endswith(".spec"), files):
         filename = outdir + "/" + f
         shutil.copyfile(f, filename)
-        _add_or_replace_define(filename, "version_unconverted", version)
+        _replace_define(filename, "version_unconverted", version,
+                        add_if_missing=False)
         if version_converted and version_converted != version:
+            _replace_define(filename, "version_unconverted", version)
             _replace_tag(filename, 'Version', version_converted)
             _replace_spec_setup(filename, "version_unconverted")
         else:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -138,14 +138,14 @@ class TestSetVersionBasics(SetVersionBaseTest):
         )
     )
     @unpack
-    def test_add_or_replace_define_replace(self, lines, expected_lines,
-                                           define_name, define_value):
+    def test_replace_define_replace(self, lines, expected_lines,
+                                    define_name, define_value):
         fn = os.path.join(self._tmpdir, "test-file")
         with open(fn, "w") as f:
             f.write("\n".join(lines))
         # do the replacement
-        sv._add_or_replace_define(os.path.basename(fn),
-                                  define_name, define_value)
+        sv._replace_define(os.path.basename(fn),
+                           define_name, define_value)
         # check
         with open(fn, "r") as f:
             current_lines = f.read().split("\n")
@@ -186,14 +186,14 @@ class TestSetVersionBasics(SetVersionBaseTest):
         )
     )
     @unpack
-    def test_add_or_replace_define_add(self, lines, expected_lines,
-                                       define_name, define_value):
+    def test_replace_define_add(self, lines, expected_lines,
+                                define_name, define_value):
         fn = os.path.join(self._tmpdir, "test-file")
         with open(fn, "w") as f:
             f.write("\n".join(lines))
         # do the addition
-        sv._add_or_replace_define(os.path.basename(fn),
-                                  define_name, define_value)
+        sv._replace_define(os.path.basename(fn),
+                           define_name, define_value)
         # check
         with open(fn, "r") as f:
             current_lines = f.read().split("\n")

--- a/tests/test_rpmspec.py
+++ b/tests/test_rpmspec.py
@@ -191,7 +191,25 @@ class SetVersionSpecfile(SetVersionBaseTest):
             "test-master.tar",
             [],
             ["test-5.1.0/test.egg-info/PKG-INFO"]
-        )
+        ),
+        (
+            "test.spec",
+            [
+                "Version: 1.2.3",
+                "Name: test",
+                "%define component test",
+                "%setup -p -n %{component}-%{version}"
+            ],
+            [
+                "Version: 5.0.0",
+                "Name: test",
+                "%define component test",
+                "%setup -p -n %{component}-%{version}"
+            ],
+            "test-master.tar",
+            [],
+            ["test-5.0.0/test.egg-info/PKG-INFO"]
+        ),
     )
     @unpack
     def test_python_package(


### PR DESCRIPTION
If the unconverted_version and version are equal, don't
add unconverted_version define if not already there.