### PR TITLE
Support version numbers beginning with v

### DIFF
--- a/set_version
+++ b/set_version
@@ -65,7 +65,7 @@ class VersionDetector(object):
     def _get_version_via_filename(files, basename):
         """ detect version based on file names"""
         for f in files:
-            regex = r"^%s.*[-_]([\d].*)\.(?:%s)$" % (re.escape(basename),
+            regex = r"^%s.*[-_]v?([\d].*)\.(?:%s)$" % (re.escape(basename),
                                                      suffixes_re)
             m = re.match(regex, f)
             if m:


### PR DESCRIPTION
The project I am currently working with uses tags of the form v0.1.0, which is relatively common. This adds support for detection of that case.