### PR TITLE
Support Python 2.6 for SLES-11 SP4

### DIFF
--- a/set_version
+++ b/set_version
@@ -22,6 +22,7 @@ import shutil
 import sys
 import tarfile
 import zipfile
+from contextlib import closing
 
 try:
     from packaging.version import LegacyVersion, Version, parse
@@ -33,6 +34,11 @@ except:
 else:
     HAS_PACKAGING = True
 
+if sys.version_info < (2,7):
+    _orig_subn = re.subn
+    def _new_subn(pattern, repl, string, count=0, flags=0):
+        return _orig_subn(re.compile(pattern, flags=flags), repl, string, count=count)
+    re.subn = _new_subn
 
 outdir = None
 suffixes = ('tar', 'tar.gz', 'tgz', 'tar.bz2', 'tbz2', 'tar.xz', 'zip')
@@ -88,7 +94,7 @@ class VersionDetector(object):
         for f in filter(lambda x: x.endswith(suffixes), files):
             # handle tarfiles
             if tarfile.is_tarfile(f):
-                with tarfile.open(f) as tf:
+                with closing(tarfile.open(f)) as tf:
                     v = VersionDetector.__get_version(tf.getnames(), basename)
                     if v:
                         return v
@@ -134,7 +140,7 @@ class PackageTypeDetector(object):
     def _is_python(f):
         names = []
         if tarfile.is_tarfile(f):
-            with tarfile.open(f) as tf:
+            with closing(tarfile.open(f)) as tf:
                 names = tf.getnames()
         if zipfile.is_zipfile(f):
             with zipfile.ZipFile(f, 'r') as zf:


### PR DESCRIPTION
Some small compatibility fixes that let set_version run with the ancient
Python 2.6 available on SLES-11 SP4
