### PR TITLE
Avoid half-converting Debian native pkgs to non-native pkgs

### DIFF
--- a/set_version
+++ b/set_version
@@ -136,6 +136,18 @@ class VersionDetector(object):
         # Nothing found
         return None
 
+    @staticmethod
+    def _get_version_via_debian_dsc(filename):
+        version = re.compile(r'^Version:([ \t\f\v]*)[^%\n\r]*', re.IGNORECASE)
+        if os.path.exists(filename):
+            with open(filename, "r") as f:
+                for line in f:
+                    versionmatch = version.match(line)
+                    if versionmatch:
+                        return versionmatch.group(0)
+        # Nothing found
+        return None
+
 
 class PackageTypeDetector(object):
     @staticmethod
@@ -347,15 +359,23 @@ if __name__ == '__main__':
         _replace_tag(filename, 'Release', "0")
 
     # handle debian packages
+    # append -0 only for non-native packages, otherwise native packages
+    # will be half-converted to non-native and break dpkg-buildpackage
     for f in filter(lambda x: x.endswith(".dsc"), files):
         filename = outdir + "/" + f
         shutil.copyfile(f, filename)
-        _replace_tag(filename, 'Version', version + "-0")
+        if "-" in VersionDetector._get_version_via_debian_dsc(filename):
+            _replace_tag(filename, 'Version', version + "-0")
+        else:
+            _replace_tag(filename, 'Version', version)
 
     for f in filter(lambda x: x.endswith(("debian.changelog")), files):
         filename = outdir + "/" + f
         shutil.copyfile(f, filename)
-        _replace_debian_changelog_version(filename, version + "-0")
+        if "-" in VersionDetector._get_version_via_debian_changelog(filename):
+            _replace_debian_changelog_version(filename, version + "-0")
+        else:
+            _replace_debian_changelog_version(filename, version)
 
     # handle build.collax recipes
     for f in filter(lambda x: x.endswith(("build.collax")), files):


### PR DESCRIPTION
Newer versions of dpkg-buildpackages are more strict in checking that
the Debian package format is consistent.
Always appending a -0 to the version causes a native package, which
must not have a - in the version, to fail to build.
Append -0 conditionally on a simple check: if the original version
has a - character then it's non-native and it's safe to add -0.

In order to do this check a new version detection static method is
added, to parse the .dsc file for the Version tag.

Commit https://github.com/openSUSE/obs-service-set_version/commit/c928f99931684be2d15dee16cb47595209e453e4 introduced this problem for packages that are in format 3.0 (native):

```
[  112s] dpkg-source: error: can't build with source format '3.0 (native)': native package version may not have a revision
[  112s] dpkg-buildpackage: error: dpkg-source -b BUILD gave error exit status 255
```