### PR TITLE
Fix #42

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.pyc
+*.pyo
 *.sw?
 set_versionc
+tests/test_newline/

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ test:
 
 clean:
 	find -name "*.pyc" -exec rm {} \;
+	find -name '*.pyo' -exec rm {} \;
 	rm -rf set_versionc
 
 .PHONY: all install test

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is an [Open Build Service](http://openbuildservice.org/) source service. It updates an RPM spec or Debian changelog according to the existing files.
 
 This is the git repository for [openSUSE:Tools/obs-service-set_version](https://build.opensuse.org/package/show/openSUSE:Tools/obs-service-set_version). The authoritative source is https://github.com/openSUSE/obs-service-set_version
- 
+
 The service can be used in combination with other services like [download_files](https://github.com/openSUSE/obs-service-download_files), [tar_scm](https://github.com/openSUSE/obs-service-tar_scm), [recompress](https://github.com/openSUSE/obs-service-recompress) or [extract_file](https://github.com/openSUSE/obs-service-extract_file) e.g. within the [GIT integration](https://en.opensuse.org/openSUSE:Build_Service_Concept_SourceService#Example_2:_GIT_integration) workflow.
 
 ## Dependencies
@@ -20,14 +20,21 @@ To run the full testsuite, some dependencies are needed:
 If the dependencies are not installed, some tests are skipped. `zypper` itself
 is also needed for the tests with python packages and PEP440 compatible versions.
 
-To run the testsuite, execute:
+To run the full testsuite, execute:
 
     python -m unittest discover tests/
 
-If ```zypper``` and/or ```dpkg``` are installed, theses tests take some time.
-The testrun may take some time. Don't forget to run also
+If ```zypper``` and/or ```dpkg``` are installed, theses tests take some time,
+but you can specify a filename pattern, which test files should be run.
+
+    python -m unittest discover -p test_b*.py tests/
+
+Don't forget to run also
 
     flake8 set_version tests/
 
+or simply use
 
+    make test
 
+to run all linters and tests

--- a/set_version
+++ b/set_version
@@ -35,6 +35,8 @@ else:
     HAS_PACKAGING = True
 
 
+DEBUG = False
+
 outdir = None
 suffixes = ('obscpio', 'tar', 'tar.gz', 'tgz', 'tar.bz2', 'tbz2', 'tar.xz',
             'zip')
@@ -50,36 +52,61 @@ def _get_local_files():
 
 
 class VersionDetector(object):
-    @staticmethod
-    def _autodetect(files, basename):
+    def __init__(self, regex=None):
+        self.regex = regex
+
+    def _autodetect(self, files, basename):
+        if DEBUG:
+            print("Starting version autodetect")
+
         version = VersionDetector._get_version_via_obsinfo(
             files, basename)
         if not version:
-            version = VersionDetector._get_version_via_archive_dirname(
+            if DEBUG:
+                print("Could not find version via obsinfo")
+            version = self._get_version_via_archive_dirname(
                 files, basename)
         if not version:
-            version = VersionDetector._get_version_via_filename(
+            if DEBUG:
+                print("Could not find version via archive dirname")
+            version = self._get_version_via_filename(
                 files, basename)
         if not version:
+            if DEBUG:
+                print("Could not find version via filename")
             version = VersionDetector._get_version_via_debian_changelog(
                 "debian.changelog")
+        if not version:
+            if DEBUG:
+                print("Could not find version via debian changelog")
         return version
 
-    @staticmethod
-    def _get_version_via_filename(files, basename):
+    def _get_version_via_filename(self, files, basename):
         """ detect version based on file names"""
+        if DEBUG:
+            print("detecting version via files")
         for f in files:
-            regex = r"^%s.*[-_]([\d].*)\.(?:%s)$" % (re.escape(basename),
-                                                     suffixes_re)
+            if DEBUG:
+                print("  - checking file ", f)
+            if self.regex:
+                if DEBUG:
+                    print("  - using regex: ", self.regex)
+                regex = self.regex
+            else:
+                regex = r"^%s.*[-_]([\d].*)\.(?:%s)$" % (re.escape(basename),
+                                                         suffixes_re)
             m = re.match(regex, f)
             if m:
                 return m.group(1)
         # Nothing found
         return None
 
-    @staticmethod
-    def __get_version(str_list, basename):
-        regex = "%s[^\/]*[-_]([\d][^\/]*).*" % basename
+    def __get_version(self, str_list, basename):
+        if self.regex:
+            regex = self.regex
+        else:
+            regex = "%s.*[-_]([\d][^\/]*).*" % basename
+
         for s in str_list:
             m = re.match(regex, s)
             if m:
@@ -87,20 +114,19 @@ class VersionDetector(object):
         # Nothing found
         return None
 
-    @staticmethod
-    def _get_version_via_archive_dirname(files, basename):
+    def _get_version_via_archive_dirname(self, files, basename):
         """ detect version based tar'd directory name"""
         for f in filter(lambda x: x.endswith(suffixes), files):
             # handle tarfiles
             if tarfile.is_tarfile(f):
                 with tarfile.open(f) as tf:
-                    v = VersionDetector.__get_version(tf.getnames(), basename)
+                    v = self.__get_version(tf.getnames(), basename)
                     if v:
                         return v
             # handle zipfiles
             if zipfile.is_zipfile(f):
                 with zipfile.ZipFile(f, 'r') as zf:
-                    v = VersionDetector.__get_version(zf.namelist(), basename)
+                    v = self.__get_version(zf.namelist(), basename)
                     if v:
                         return v
         # Nothing found
@@ -283,6 +309,15 @@ def _version_python_pip2rpm(version_pip):
     return version_rpm
 
 
+def _version_detect(args, files_local):
+    vdetect = VersionDetector(args['regex'])
+    ver = vdetect._autodetect(files_local, args["basename"])
+    if DEBUG:
+        print("Found version '%s'" % ver)
+
+    return ver
+
+
 if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(
@@ -300,11 +335,13 @@ if __name__ == '__main__':
     parser.add_argument('--file', action='append',
                         help='modify only this build description. '
                         'maybe used multiple times.')
+    parser.add_argument('--debug', default=False,
+                        help='Enable more verbose output.')
+    parser.add_argument('--regex',
+                        help='regex to be used by autodetect')
     args = vars(parser.parse_args())
 
     version = args['version']
-
-    files_local = _get_local_files()
 
     outdir = args['outdir']
 
@@ -312,8 +349,14 @@ if __name__ == '__main__':
         print("no outdir specified")
         sys.exit(-1)
 
+    if args['debug']:
+        print("Running in debug mode")
+        DEBUG = True
+
+    files_local = _get_local_files()
+
     if not version:
-        version = VersionDetector._autodetect(files_local, args["basename"])
+        version = _version_detect(args, files_local)
 
     if not version:
         print("unable to detect the version")

--- a/set_version
+++ b/set_version
@@ -52,40 +52,38 @@ def _get_local_files():
 
 
 class VersionDetector(object):
-    def __init__(self, regex=None):
+    def __init__(self, regex=None, file_list=(), basename=''):
         self.regex = regex
+        self.file_list = file_list
+        self.basename = basename
 
-    def _autodetect(self, files, basename):
+    def autodetect(self):
         if DEBUG:
             print("Starting version autodetect")
 
-        version = VersionDetector._get_version_via_obsinfo(
-            files, basename)
+        version = self._get_version_via_obsinfo()
         if not version:
             if DEBUG:
                 print("Could not find version via obsinfo")
-            version = self._get_version_via_archive_dirname(
-                files, basename)
+            version = self._get_version_via_archive_dirname()
         if not version:
             if DEBUG:
                 print("Could not find version via archive dirname")
-            version = self._get_version_via_filename(
-                files, basename)
+            version = self._get_version_via_filename()
         if not version:
             if DEBUG:
                 print("Could not find version via filename")
-            version = VersionDetector._get_version_via_debian_changelog(
-                "debian.changelog")
+            version = self.get_version_via_debian_changelog("debian.changelog")
         if not version:
             if DEBUG:
                 print("Could not find version via debian changelog")
         return version
 
-    def _get_version_via_filename(self, files, basename):
+    def _get_version_via_filename(self):
         """ detect version based on file names"""
         if DEBUG:
             print("detecting version via files")
-        for f in files:
+        for f in self.file_list:
             if DEBUG:
                 print("  - checking file ", f)
             if self.regex:
@@ -93,19 +91,20 @@ class VersionDetector(object):
                     print("  - using regex: ", self.regex)
                 regex = self.regex
             else:
-                regex = r"^%s.*[-_]([\d].*)\.(?:%s)$" % (re.escape(basename),
-                                                         suffixes_re)
+                regex = r"^%s.*[-_]([\d].*)\.(?:%s)$" % (
+                    re.escape(self.basename),
+                    suffixes_re)
             m = re.match(regex, f)
             if m:
                 return m.group(1)
         # Nothing found
         return None
 
-    def __get_version(self, str_list, basename):
+    def __get_version(self, str_list):
         if self.regex:
             regex = self.regex
         else:
-            regex = "%s.*[-_]([\d][^\/]*).*" % basename
+            regex = "%s.*[-_]([\d][^\/]*).*" % self.basename
 
         for s in str_list:
             m = re.match(regex, s)
@@ -114,30 +113,29 @@ class VersionDetector(object):
         # Nothing found
         return None
 
-    def _get_version_via_archive_dirname(self, files, basename):
+    def _get_version_via_archive_dirname(self):
         """ detect version based tar'd directory name"""
-        for f in filter(lambda x: x.endswith(suffixes), files):
+        for f in filter(lambda x: x.endswith(suffixes), self.file_list):
             # handle tarfiles
             if tarfile.is_tarfile(f):
                 with tarfile.open(f) as tf:
-                    v = self.__get_version(tf.getnames(), basename)
+                    v = self.__get_version(tf.getnames())
                     if v:
                         return v
             # handle zipfiles
             if zipfile.is_zipfile(f):
                 with zipfile.ZipFile(f, 'r') as zf:
-                    v = self.__get_version(zf.namelist(), basename)
+                    v = self.__get_version(zf.namelist())
                     if v:
                         return v
         # Nothing found
         return None
 
-    @staticmethod
-    def _get_version_via_obsinfo(files, basename):
-        join_suffix = basename + ".obsinfo"
-        for filename in filter(lambda x: x.endswith(join_suffix), files):
-            if os.path.exists(filename):
-                with codecs.open(filename, 'r', 'utf8') as fp:
+    def _get_version_via_obsinfo(self):
+        join_suffix = self.basename + ".obsinfo"
+        for fname in filter(lambda x: x.endswith(join_suffix), self.file_list):
+            if os.path.exists(fname):
+                with codecs.open(fname, 'r', 'utf8') as fp:
                     for line in fp:
                         if line.startswith("version: "):
                             string = line[9:]
@@ -147,7 +145,7 @@ class VersionDetector(object):
         return None
 
     @staticmethod
-    def _get_version_via_debian_changelog(filename):
+    def get_version_via_debian_changelog(filename):
         # from http://anonscm.debian.org/cgit/pkg-python-debian/\
             # python-debian.git/tree/lib/debian/changelog.py
         topline = re.compile(r'^(\w%(name_chars)s*) \(([^\(\) \t]+)\)'
@@ -177,6 +175,7 @@ class VersionDetector(object):
 
 
 class PackageTypeDetector(object):
+    # pylint: disable=too-few-public-methods
     @staticmethod
     def _get_package_type(files):
         pt_found = False
@@ -270,12 +269,11 @@ def _replace_tag(filename, tag, string):
             f.write(contents_new)
 
 
-def _replace_debian_changelog_version(filename, version_new):
+def _replace_debian_changelog_version(fname, version_new):
     # first, modify a copy of filename and then move it
     # get current version
-    version_current = VersionDetector._get_version_via_debian_changelog(
-        filename)
-    with codecs.open(filename, 'r+', 'utf8') as f:
+    version_current = VersionDetector.get_version_via_debian_changelog(fname)
+    with codecs.open(fname, 'r+', 'utf8') as f:
         content_lines = f.readlines()
         f.seek(0)
         content_lines[0] = content_lines[0].replace(
@@ -310,8 +308,8 @@ def _version_python_pip2rpm(version_pip):
 
 
 def _version_detect(args, files_local):
-    vdetect = VersionDetector(args['regex'])
-    ver = vdetect._autodetect(files_local, args["basename"])
+    vdetect = VersionDetector(args['regex'], files_local, args["basename"])
+    ver = vdetect.autodetect()
     if DEBUG:
         print("Found version '%s'" % ver)
 
@@ -399,7 +397,7 @@ if __name__ == '__main__':
     for f in filter(lambda x: x.endswith(("debian.changelog")), files):
         filename = outdir + "/" + f
         shutil.copyfile(f, filename)
-        if "-" in VersionDetector._get_version_via_debian_changelog(filename):
+        if "-" in VersionDetector.get_version_via_debian_changelog(filename):
             _replace_debian_changelog_version(filename, version + "-0")
         else:
             _replace_debian_changelog_version(filename, version)

--- a/set_version.service
+++ b/set_version.service
@@ -12,5 +12,9 @@ Can be used after download_url or tar_scm service.
   <parameter name="file">
     <description>Update only the given file.</description>
   </parameter>
+  <parameter name="regex">
+    <description>This regex can be used to autodetect the version from the source dir
+inside the source file or the source file directly.</description>
+  </parameter>
 </service>
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -248,3 +248,20 @@ class TestSetVersionBasics(SetVersionBaseTest):
             self.assertEqual(len(current_lines), len(expected_lines))
             for nbr, l in enumerate(current_lines):
                 self.assertEqual(l, expected_lines[nbr])
+
+    def test_autodetect_filename(self):
+        dname = os.path.join(self._tmpdir, "test-v1.2.3")
+        os.chdir(self._tmpdir)
+        os.mkdir(dname)
+        subprocess.call(['tar', '-cf', 'test-v1.2.3.tar', 'test-v1.2.3'])
+        files_local = ['test-v1.2.3.tar']
+
+        # checking dirname in archive detection
+        args = {'regex': '^test-v(.*)', 'basename': ''}
+        ver = sv._version_detect(args, files_local)
+        self.assertEqual(ver, '1.2.3')
+
+        # checking archive filename detection
+        args = {'regex': '^test-v(.*).tar', 'basename': ''}
+        ver = sv._version_detect(args, files_local)
+        self.assertEqual(ver, '1.2.3')

--- a/tests/test_rpmspec.py
+++ b/tests/test_rpmspec.py
@@ -57,7 +57,8 @@ class SetVersionSpecfile(SetVersionBaseTest):
     def test_version_from_obsinfo(self):
         obsinfo = self._write_obsinfo("test.obsinfo", "0.0.1")
         files = [obsinfo]
-        ver = sv.VersionDetector._get_version_via_obsinfo(files, '')
+        vdetector = sv.VersionDetector(None, files, '')
+        ver = vdetector._get_version_via_obsinfo()
         self.assertEqual(ver, "0.0.1")
 
     @file_data("data_test_from_commandline.json")


### PR DESCRIPTION
This PR is intended to fix #42 

It adds two new cli options:

* '--debug' - for better debugging output (can only be used locally - no param in service file)
* '--regex' - specify a regex which is used in _get_version_via_filename and _get_version_via_archive_dirname to detect the version

Additionally I refactored the class VersionDetector to make more use of attributes instead of method parameters