### PR TITLE
Don't let version check get beyond directory boundary

### DIFF
--- a/set_version
+++ b/set_version
@@ -78,7 +78,7 @@ class VersionDetector(object):
 
     @staticmethod
     def __get_version(str_list, basename):
-        regex = "%s.*[-_]([\d][^\/]*).*" % basename
+        regex = "%s[^\/]*[-_]([\d][^\/]*).*" % basename
         for s in str_list:
             m = re.match(regex, s)
             if m:


### PR DESCRIPTION
With archive containing files like "druid-0.9.2/extensions/druid-avro-extensions/avro-1.7.7.jar" set_version incorrectly guessed "1.7.7.jar" as the version instead of "0.9.2".