### PR TITLE
enforce files to be decoded as UTF-8

### DIFF
--- a/set_version
+++ b/set_version
@@ -22,6 +22,7 @@ import shutil
 import sys
 import tarfile
 import zipfile
+import codecs
 
 try:
     from packaging.version import LegacyVersion, Version, parse
@@ -110,7 +111,7 @@ class VersionDetector(object):
         join_suffix = basename + ".obsinfo"
         for filename in filter(lambda x: x.endswith(join_suffix), files):
             if os.path.exists(filename):
-                with open(filename, "r") as fp:
+                with codecs.open(filename, 'r', 'utf8') as fp:
                     for line in fp:
                         if line.startswith("version: "):
                             string = line[9:]
@@ -128,7 +129,7 @@ class VersionDetector(object):
                              % {'name_chars': '[-+0-9a-z.]'},
                              re.IGNORECASE)
         if os.path.exists(filename):
-            with open(filename, "r") as f:
+            with codecs.open(filename, 'r', 'utf8') as f:
                 firstline = f.readline()
                 topmatch = topline.match(firstline)
                 if topmatch:
@@ -140,7 +141,7 @@ class VersionDetector(object):
     def _get_version_via_debian_dsc(filename):
         version = re.compile(r'^Version:([ \t\f\v]*)[^%\n\r]*', re.IGNORECASE)
         if os.path.exists(filename):
-            with open(filename, "r") as f:
+            with codecs.open(filename, 'r', 'utf8') as f:
                 for line in f:
                     versionmatch = version.match(line)
                     if versionmatch:
@@ -177,7 +178,7 @@ class PackageTypeDetector(object):
 
 def _replace_define(filename, def_name, def_value, add_if_missing=True):
     # first, modify a copy of filename and then move it
-    with open(filename, 'r+') as f:
+    with codecs.open(filename, 'r+', 'utf8') as f:
         contents = f.read()
         f.seek(0)
         contents_new, subs = re.subn(
@@ -200,7 +201,7 @@ def _replace_define(filename, def_name, def_value, add_if_missing=True):
 
 def _replace_spec_setup(filename, version_define):
     # first, modify a copy of filename and then move it
-    with open(filename, 'r+') as f:
+    with codecs.open(filename, 'r+', 'utf8') as f:
         contents = f.read()
         f.seek(0)
         # %setup without "-n" uses implicit "-n" as "%{name}-%{version}"
@@ -223,7 +224,7 @@ def _replace_spec_setup(filename, version_define):
 
 def _replace_tag(filename, tag, string):
     # first, modify a copy of filename and then move it
-    with open(filename, 'r+') as f:
+    with codecs.open(filename, 'r+', 'utf8') as f:
         contents = f.read()
         f.seek(0)
         if filename.endswith("PKGBUILD") or filename.endswith("build.collax"):
@@ -248,7 +249,7 @@ def _replace_debian_changelog_version(filename, version_new):
     # get current version
     version_current = VersionDetector._get_version_via_debian_changelog(
         filename)
-    with open(filename, 'r+') as f:
+    with codecs.open(filename, 'r+', 'utf8') as f:
         content_lines = f.readlines()
         f.seek(0)
         content_lines[0] = content_lines[0].replace(

--- a/tests/fixtures/broken-utf8.spec
+++ b/tests/fixtures/broken-utf8.spec
@@ -1,0 +1,69 @@
+#
+# spec file for package rawspeed
+#
+# Copyright (c) 2017 SUSE LINUX Products GmbH, Nuernberg, Germany.
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via http://bugs.opensuse.org/
+#
+
+Name:           rawspeed
+Version:        0
+Release:        0
+License:        LGPL-2.1
+Summary:        Fast raw decoding library
+Url:            https://github.com/darktable-org/rawspeed
+Group:          System/Libraries
+Source:         %{name}-%{version}.tar.xz
+BuildRequires:  cmake >= 3
+BuildRequires:  gcc-c++ >= 4.9
+BuildRequires:  libxml2-tools
+BuildRequires:  pkgconfig
+BuildRequires:  pugixml-devel
+BuildRequires:  libjpeg-devel
+BuildRequires:  zlib-devel
+BuildRequires:  googletest-source
+BuildRoot:      %{_tmppath}/%{name}-%{version}-build
+
+%description
+RawSpeed…
+
+- is capable of decoding various images in RAW file format.
+- is intended to provide the fastest decoding speed possible.
+- supports the most common DSLR and similar class brands.
+- supplies unmodified RAW data, optionally scaled to 16 bit, or normalized to 0->1 float point data.
+- supplies CFA layout for all known cameras.
+- provides automatic black level calculation for cameras having such information.
+- optionally crops off  “junk” areas of images, containing no valid image information.
+- can add support for new cameras by adding definitions to an xml file.
+- ~~is extensively crash-tested on broken files~~.
+- decodes images from memory, not a file stream. You can use a memory mapped file, but it is rarely faster.
+- open source under the LGPL v2 license.
+
+%prep
+%setup -q
+
+%build
+%cmake -DGOOGLETEST_PATH:PATH=%{_datadir}/googletest-source/ -DBUILD_SHARED_LIBS:BOOL=OFF
+make %{?_smp_mflags}
+
+%check
+%ctest
+
+%install
+%cmake_install
+
+%files
+%defattr(-,root,root)
+%{_bindir}/rs-identify
+%dir %{_datadir}/rawspeed/
+%{_datadir}/rawspeed/cameras.xml
+%{_datadir}/rawspeed/showcameras.xsl

--- a/tests/test_rpmspec.py
+++ b/tests/test_rpmspec.py
@@ -17,6 +17,7 @@
 
 import os
 import imp
+import shutil
 from ddt import data, ddt, file_data, unpack
 
 from test_base import SetVersionBaseTest
@@ -260,3 +261,11 @@ class SetVersionSpecfile(SetVersionBaseTest):
             self.assertEqual(len(current_lines), len(expected_spec_lines))
             for nbr, l in enumerate(current_lines):
                 self.assertEqual(l, expected_spec_lines[nbr])
+
+    def test_broken_utf8_spec(self):
+        fn = os.path.join(os.path.dirname(__file__), 'fixtures',
+                          'broken-utf8.spec')
+        nfn = fn + "1"
+        shutil.copyfile(fn, nfn)
+        sv._replace_spec_setup(nfn, '0.0.1')
+        os.unlink(nfn)


### PR DESCRIPTION
fixes buildtime problems with utf-8 characters, already tested in containers - should work either. No need of locales in container