### PR TITLE
Add build-dependency on flake8 to fix Debian builds

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: obs-service-set-version
 Section: devel
 Priority: extra
 Maintainer: Daniel Gollub <dgollub@brocade.com>
-Build-Depends: debhelper (>= 8.0.0)
+Build-Depends: debhelper (>= 8.0.0), python, flake8 | python-flake8, python-ddt, python-packaging
 Standards-Version: 3.9.3
 Homepage: https://github.com/openSUSE/obs-service-set_version
 


### PR DESCRIPTION
Fixes build on Debian 9 and 10 and newer Ubuntu versions.

Note that older versions of Debian don't have all the required packages for the unit tests, so either the tests have to be disabled or support for those versions has to be dropped. Same for Ubuntu.