### PR TITLE
Fix basename to match documentation

### DIFF
--- a/set_version
+++ b/set_version
@@ -132,8 +132,7 @@ class VersionDetector(object):
         return None
 
     def _get_version_via_obsinfo(self):
-        join_suffix = self.basename + ".obsinfo"
-        for fname in filter(lambda x: x.endswith(join_suffix), self.file_list):
+        for fname in filter(lambda x: x.startswith(self.basename) and x.endswith(".obsinfo"), self.file_list):
             if os.path.exists(fname):
                 with codecs.open(fname, 'r', 'utf8') as fp:
                     for line in fp:


### PR DESCRIPTION
The docs for "basename" say:
"Limit version detection to files which start with given name."

Adjust the code to behave as documented, match only files that start
with "basename" and end with ".obsinfo".

Signed-off-by: Olaf Hering <olaf@aepfle.de>