### PR TITLE
Fix indentation of condition

### DIFF
--- a/set_version
+++ b/set_version
@@ -132,7 +132,8 @@ class VersionDetector(object):
         return None
 
     def _get_version_via_obsinfo(self):
-        for fname in filter(lambda x: x.startswith(self.basename) and x.endswith(".obsinfo"), self.file_list):
+        for fname in filter(lambda x: x.startswith(self.basename) and
+                            x.endswith(".obsinfo"), self.file_list):
             if os.path.exists(fname):
                 with codecs.open(fname, 'r', 'utf8') as fp:
                     for line in fp:


### PR DESCRIPTION
This caused the test suite to fail because of linting issues:

  set_version:135:80: E501 line too long (110 > 79 characters)
  Makefile:13: recipe for target 'test' failed
  make: *** [test] Error 1