### PR TITLE
Fix Debian version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 prefix = /usr
-PYTHON := python
+PYTHON ?= python
 
 servicedir = ${prefix}/lib/obs/service
 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: obs-service-set-version
 Section: devel
 Priority: extra
 Maintainer: Daniel Gollub <dgollub@brocade.com>
-Build-Depends: debhelper (>= 8.0.0), python, flake8 | python-flake8, python-ddt, python-packaging
+Build-Depends: debhelper (>= 8.0.0), python3, flake8 | python3-flake8, python3-ddt, python3-packaging
 Standards-Version: 3.9.3
 Homepage: https://github.com/openSUSE/obs-service-set_version
 

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: https://github.com/openSUSE/obs-service-set_version
 
 Package: obs-service-set-version
 Architecture: all
-Depends: ${misc:Depends}, sed
+Depends: ${misc:Depends}, sed, python3
 Description: An OBS source service: Update spec file version
  This is a source service for openSUSE Build Service.
  Very simply script to update the version in .spec or .dsc files according to

--- a/debian/rules
+++ b/debian/rules
@@ -2,6 +2,7 @@
 # -*- makefile -*-
 #
 export DH_VERBOSE=1
+export PYTHON=python3
 
 %:
 	dh $@ 

--- a/debian/rules
+++ b/debian/rules
@@ -5,4 +5,9 @@ export DH_VERBOSE=1
 export PYTHON=python3
 
 %:
-	dh $@ 
+	dh $@
+
+override_dh_auto_build:
+	dh_auto_build $@
+	sed -i -e '1 s,^#!/usr/bin/python$$,#!/usr/bin/python3,' set_version
+


### PR DESCRIPTION
On Debian, python2 dependencies no longer exist on newer distro versions. Use python3 instead.
