### PR TITLE
fix suffixes to begin with a dot

### DIFF
--- a/set_version
+++ b/set_version
@@ -37,6 +37,9 @@ else:
 
 DEBUG = False
 
+if os.environ.get('DEBUG_SET_VERSION') == "1":
+    DEBUG = True
+
 outdir = None
 suffixes = ('obscpio', 'tar', 'tar.gz', 'tgz', 'tar.bz2', 'tbz2', 'tar.xz',
             'zip')
@@ -61,22 +64,27 @@ class VersionDetector(object):
         if DEBUG:
             print("Starting version autodetect")
 
+        if DEBUG:
+            print("-- Starting version detection via obsinfo")
         version = self._get_version_via_obsinfo()
         if not version:
             if DEBUG:
-                print("Could not find version via obsinfo")
+                print("--- Could not find version via obsinfo")
+                print("-- Starting version detection via archive dirname")
             version = self._get_version_via_archive_dirname()
         if not version:
             if DEBUG:
-                print("Could not find version via archive dirname")
+                print("--- Could not find version via archive dirname")
+                print("-- Starting version detection via filename")
             version = self._get_version_via_filename()
         if not version:
             if DEBUG:
-                print("Could not find version via filename")
+                print("--- Could not find version via filename")
+                print("-- Starting version detection via debian changelog")
             version = self.get_version_via_debian_changelog("debian.changelog")
         if not version:
             if DEBUG:
-                print("Could not find version via debian changelog")
+                print("--- Could not find version via debian changelog")
         return version
 
     def _get_version_via_filename(self):
@@ -116,6 +124,8 @@ class VersionDetector(object):
     def _get_version_via_archive_dirname(self):
         """ detect version based tar'd directory name"""
         for f in filter(lambda x: x.endswith(suffixes), self.file_list):
+            if DEBUG:
+                print("Checking path: '%s'." % f)
             # handle tarfiles
             if tarfile.is_tarfile(f):
                 with tarfile.open(f) as tf:

--- a/set_version
+++ b/set_version
@@ -41,8 +41,8 @@ if os.environ.get('DEBUG_SET_VERSION') == "1":
     DEBUG = True
 
 outdir = None
-suffixes = ('obscpio', 'tar', 'tar.gz', 'tgz', 'tar.bz2', 'tbz2', 'tar.xz',
-            'zip')
+suffixes = ('\.obscpio', '\.tar', '\.tar.gz', '\.tgz', '\.tar.bz2', '\.tbz2',
+            '\.tar.xz', '\.zip')
 suffixes_re = "|".join(map(lambda x: re.escape(x), suffixes))
 
 
@@ -99,7 +99,7 @@ class VersionDetector(object):
                     print("  - using regex: ", self.regex)
                 regex = self.regex
             else:
-                regex = r"^%s.*[-_]([\d].*)\.(?:%s)$" % (
+                regex = r"^%s.*[-_]([\d].*)(?:%s)$" % (
                     re.escape(self.basename),
                     suffixes_re)
             m = re.match(regex, f)
@@ -126,6 +126,10 @@ class VersionDetector(object):
         for f in filter(lambda x: x.endswith(suffixes), self.file_list):
             if DEBUG:
                 print("Checking path: '%s'." % f)
+            if not os.path.isfile(f):
+                if DEBUG:
+                    print("Skipping path: '%s' is not a regular file." % f)
+                continue
             # handle tarfiles
             if tarfile.is_tarfile(f):
                 with tarfile.open(f) as tf:
@@ -206,6 +210,10 @@ class PackageTypeDetector(object):
     @staticmethod
     def _is_python(f):
         names = []
+        if not os.path.isfile(f):
+            if DEBUG:
+                print("Skipping path: '%s' is not a regular file." % f)
+            return False
         if tarfile.is_tarfile(f):
             with tarfile.open(f) as tf:
                 names = tf.getnames()

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -28,6 +28,9 @@ import unittest
 
 from ddt import data, ddt, unpack
 
+DEBUG = False
+if os.environ.get('DEBUG_SET_VERSION') == "1":
+    DEBUG = True
 
 # NOTE(toabctl): Hack to import non-module file for testing
 sv = imp.load_source("set_version", "set_version")
@@ -97,12 +100,16 @@ class SetVersionBaseTest(unittest.TestCase):
             shutil.rmtree(self._tmpoutdir)
         except subprocess.CalledProcessError as e:
             raise Exception(
-                "Can not call '%s' in dir '%s'. Error: %s" % ("".join(cmd),
+                "Can not call '%s' in dir '%s'. Error: %s" % (" ".join(cmd),
                                                               self._tmpdir,
                                                               e.output))
 
     def tearDown(self):
-        shutil.rmtree(self._tmpdir)
+        if DEBUG:
+            print("DEBUG_SET_VERSION enabled: Please remove '%s' manually."
+                  % self._tmpdir)
+        else:
+            shutil.rmtree(self._tmpdir)
 
 
 @ddt

--- a/tests/test_rpmspec.py
+++ b/tests/test_rpmspec.py
@@ -117,6 +117,8 @@ class SetVersionSpecfile(SetVersionBaseTest):
                                          {"Name": "foo",
                                           "Version": old_version,
                                           "Group": "AnyGroup"})
+        os.mkdir(os.path.join(self._tmpdir, "pristine-tar"))
+        os.mkdir(os.path.join(self._tmpdir, "pristine.tar"))
         self._run_set_version()
         self._check_file_assert_contains(spec_path, expected_version)
         self._check_file_assert_contains(spec_path, "Name: foo")


### PR DESCRIPTION
Without this fix, if a package ends with one of the strings in the suffix
(like e.g. pristine-tar) set_version tries to unpack it. In this example
it finds a directory which ends with "tar" which is the leftover from the
tar_scm service and the attempt of unpacking results in an exception.

```
  File "/usr/lib64/python3.8/gzip.py", line 173, in __init__
    fileobj = self.myfileobj = builtins.open(filename, mode or 'rb')
IsADirectoryError: [Errno 21] Is a directory: 'pristine-tar'
```