### PR TITLE
fixing suffixes - remove backslashes

### DIFF
--- a/set_version
+++ b/set_version
@@ -41,8 +41,8 @@ if os.environ.get('DEBUG_SET_VERSION') == "1":
     DEBUG = True
 
 outdir = None
-suffixes = ('\.obscpio', '\.tar', '\.tar.gz', '\.tgz', '\.tar.bz2', '\.tbz2',
-            '\.tar.xz', '\.zip')
+suffixes = ('.obscpio', '.tar', '.tar.gz', '.tgz', '.tar.bz2', '.tbz2',
+            '.tar.xz', '.zip')
 suffixes_re = "|".join(map(lambda x: re.escape(x), suffixes))
 
 


### PR DESCRIPTION
the backslash seems not to be needed (breaks everything) because of string
interpolation.