### PR TITLE
Add zst to recognized suffixes (zstd support)

### DIFF
--- a/set_version
+++ b/set_version
@@ -42,7 +42,7 @@ if os.environ.get('DEBUG_SET_VERSION') == "1":
 
 outdir = None
 suffixes = ('.obscpio', '.tar', '.tar.gz', '.tgz', '.tar.bz2', '.tbz2',
-            '.tar.xz', '.zip')
+            '.tar.xz', '.tar.zst', '.zip')
 suffixes_re = "|".join(map(lambda x: re.escape(x), suffixes))
 
 


### PR DESCRIPTION
The `recompress` service already [supports](https://github.com/openSUSE/obs-service-recompress/commit/946b23f9de0927197d8039e386e414d4ecb9ac32) zstd, as this is commonly used together `set_version` should also support zstd.