### PR TITLE
Add new switch --fromfile

### DIFF
--- a/set_version
+++ b/set_version
@@ -55,10 +55,12 @@ def _get_local_files():
 
 
 class VersionDetector(object):
-    def __init__(self, regex=None, file_list=(), basename=''):
+    def __init__(self, regex=None, file_list=(), basename='',
+                 versionfile=None):
         self.regex = regex
         self.file_list = file_list
         self.basename = basename
+        self.versionfile = versionfile
 
     def autodetect(self):
         if DEBUG:
@@ -70,6 +72,11 @@ class VersionDetector(object):
         if not version:
             if DEBUG:
                 print("--- Could not find version via obsinfo")
+                print("-- Starting version detection via specified file")
+            version = self._get_version_via_versionfile()
+        if not version:
+            if DEBUG:
+                print("--- Could not find version via specified file")
                 print("-- Starting version detection via archive dirname")
             version = self._get_version_via_archive_dirname()
         if not version:
@@ -106,6 +113,39 @@ class VersionDetector(object):
             if m:
                 return m.group(1)
         # Nothing found
+        return None
+
+    def _get_version_via_versionfile(self):
+        """ detect version based on custom file contents"""
+        if DEBUG:
+            print("detecting version via custom file")
+
+        if not self.versionfile:
+            if DEBUG:
+                print("Custom file name not set")
+            return None
+
+        if DEBUG:
+            print("  - checking file ", self.versionfile)
+
+        if self.regex:
+            regex = self.regex
+        else:
+            regex = r"^[Vv]ersion:\s+([\d].*)(?:)\s?$"
+
+        if DEBUG:
+            print("  - using regex: ", regex)
+
+        if not os.path.exists(self.versionfile):
+            if DEBUG:
+                print("  - file: %s does not exist", self.versionfile)
+            return None
+
+        with codecs.open(self.versionfile, 'r', 'utf8') as fp:
+            for line in fp:
+                m = re.match(regex, line)
+                if m:
+                    return m.group(1)
         return None
 
     def __get_version(self, str_list):
@@ -338,7 +378,8 @@ def _version_python_pip2rpm(version_pip):
 
 
 def _version_detect(args, files_local):
-    vdetect = VersionDetector(args['regex'], files_local, args["basename"])
+    vdetect = VersionDetector(args['regex'], files_local, args["basename"],
+                              args["fromfile"])
     ver = vdetect.autodetect()
     if DEBUG:
         print("Found version '%s'" % ver)
@@ -367,6 +408,9 @@ if __name__ == '__main__':
                         help='Enable more verbose output.')
     parser.add_argument('--regex',
                         help='regex to be used by autodetect')
+    parser.add_argument('--fromfile',
+                        help='detect version based on the '
+                             'file contents and regex')
     args = vars(parser.parse_args())
 
     version = args['version']

--- a/set_version.service
+++ b/set_version.service
@@ -12,6 +12,9 @@ Can be used after download_url or tar_scm service.
   <parameter name="file">
     <description>Update only the given file.</description>
   </parameter>
+  <parameter name="fromfile">
+    <description>Try to detect version from the contents of the given file.</description>
+  </parameter>
   <parameter name="regex">
     <description>This regex can be used to autodetect the version from the source dir
 inside the source file or the source file directly.</description>

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -264,11 +264,11 @@ class TestSetVersionBasics(SetVersionBaseTest):
         files_local = ['test-v1.2.3.tar']
 
         # checking dirname in archive detection
-        args = {'regex': '^test-v(.*)', 'basename': ''}
+        args = {'regex': '^test-v(.*)', 'basename': '', 'fromfile': None}
         ver = sv._version_detect(args, files_local)
         self.assertEqual(ver, '1.2.3')
 
         # checking archive filename detection
-        args = {'regex': '^test-v(.*).tar', 'basename': ''}
+        args = {'regex': '^test-v(.*).tar', 'basename': '', 'fromfile': None}
         ver = sv._version_detect(args, files_local)
         self.assertEqual(ver, '1.2.3')


### PR DESCRIPTION
Introduces a new switch --fromfile that enables set_version to detect
the version from the contents of a given file based on a default or
custom regex ( defined via the --regex switch )