### PR TITLE
Remove usage of deprecated imp module with importlib

### DIFF
--- a/tests/loader.py
+++ b/tests/loader.py
@@ -1,0 +1,16 @@
+import importlib.machinery
+import importlib.util
+from pathlib import Path
+
+
+def import_set_version():
+    """Imports the set_version script as a python module and returns it."""
+    loader = importlib.machinery.SourceFileLoader(
+        'set_version',
+        str(Path(__file__).parent.joinpath("..", "set_version"))
+    )
+    spec = importlib.util.spec_from_loader('set_version', loader)
+    sv = importlib.util.module_from_spec(spec)
+    loader.exec_module(sv)
+
+    return sv

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -15,7 +15,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,USA.
 
 
-import imp
 import os
 import re
 import shutil
@@ -25,15 +24,15 @@ import tarfile
 import tempfile
 import unittest
 
-
 from ddt import data, ddt, unpack
+
+from loader import import_set_version
 
 DEBUG = False
 if os.environ.get('DEBUG_SET_VERSION') == "1":
     DEBUG = True
 
-# NOTE(toabctl): Hack to import non-module file for testing
-sv = imp.load_source("set_version", "set_version")
+sv = import_set_version()
 
 
 SET_VERSION_EXECUTABLE = os.path.abspath(

--- a/tests/test_package_type_detection.py
+++ b/tests/test_package_type_detection.py
@@ -15,15 +15,13 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,USA.
 
 
-import imp
-
 from ddt import data, ddt, unpack
 
 from test_base import SetVersionBaseTest
+from tests.loader import import_set_version
 
 
-# NOTE(toabctl): Hack to import non-module file for testing
-sv = imp.load_source("set_version", "set_version")
+sv = import_set_version()
 
 
 @ddt

--- a/tests/test_python_pip2rpm.py
+++ b/tests/test_python_pip2rpm.py
@@ -15,7 +15,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,USA.
 
 
-import imp
 import os
 import subprocess
 import unittest
@@ -25,10 +24,10 @@ from ddt import data, ddt, unpack
 from packaging.version import parse
 
 from test_base import SetVersionBaseTest
+from tests.loader import import_set_version
 
 
-# NOTE(toabctl): Hack to import non-module file for testing
-sv = imp.load_source("set_version", "set_version")
+sv = import_set_version()
 
 
 def _has_zypper():

--- a/tests/test_rpmspec.py
+++ b/tests/test_rpmspec.py
@@ -16,13 +16,13 @@
 
 
 import os
-import imp
 import shutil
 from ddt import data, ddt, file_data, unpack
 
 from test_base import SetVersionBaseTest
+from tests.loader import import_set_version
 
-sv = imp.load_source("set_version", "set_version")
+sv = import_set_version()
 
 
 @ddt


### PR DESCRIPTION
imp has been deprecated since python 3.3 and has been removed in python 3.12