### PR TITLE
Treat LegacyVersion as InvalidVersion

### DIFF
--- a/set_version
+++ b/set_version
@@ -375,6 +375,9 @@ def _version_python_pip2rpm(version_pip):
 
     try:
         v = parse(version_pip)
+        with suppress(NameError):
+            if isinstance(v, LegacyVersion):
+                raise InvalidVersion
     except InvalidVersion:
         # Maybe is converted already?
         return None


### PR DESCRIPTION
This resolves a behavior difference with the packaging 21.3 version on Leap 15.2 where parsing('1.7.40~svn') does not raise an InvalidVersion exception but returns "<LegacyVersion('1.7.40~svn')>" instead.