### PR TITLE
Skip the change of the pkgrel variable in PKGBUILD (only relevant for…

### DIFF
--- a/set_version
+++ b/set_version
@@ -420,11 +420,17 @@ if __name__ == '__main__':
     parser.add_argument('--fromfile',
                         help='detect version based on the '
                              'file contents and regex')
+    parser.add_argument('--skip-change-pkgrel',
+                        choices=['yes', 'no'], default='no',
+                        help='skip the change of the pkgrel variable in PKGBUILD '
+                             '(only relevant for Arch builds)')
     args = vars(parser.parse_args())
 
     version = args['version']
 
     outdir = args['outdir']
+
+    skip_change_pkgrel = bool(args['skip_change_pkgrel'] == 'yes')
 
     if not outdir:
         print("no outdir specified")
@@ -507,4 +513,5 @@ if __name__ == '__main__':
         _replace_tag(filename, "md5sums", "('SKIP')")
         _replace_tag(filename, "sha256sums", "('SKIP')")
         _replace_tag(filename, "pkgver", version)
-        _replace_tag(filename, "pkgrel", "0")
+        if not skip_change_pkgrel:
+            _replace_tag(filename, "pkgrel", "0")

--- a/set_version.service
+++ b/set_version.service
@@ -19,5 +19,9 @@ Can be used after download_url or tar_scm service.
     <description>This regex can be used to autodetect the version from the source dir
 inside the source file or the source file directly.</description>
   </parameter>
+  <parameter name="skip-change-pkgrel">
+    <description>Skip the change of the pkgrel variable in PKGBUILD (only relevant for Arch builds).</description>
+    <allowedvalue>yes</allowedvalue>
+  </parameter>
 </service>
 


### PR DESCRIPTION
… Arch builds)

Prevents the release determined by the build system from being overwritten with `pkgrel=0`.

Example:
```
  <service mode="buildtime" name="set_version">
    <param name="skip-change-pkgrel">yes</param>
  </service>
```

See also https://github.com/openSUSE/obs-build/pull/1043
